### PR TITLE
NumberInput: display digits per interface locale

### DIFF
--- a/src/NumberInput.svelte
+++ b/src/NumberInput.svelte
@@ -21,7 +21,7 @@
 />
 
 <script>
-import {ar_nums, en_nums, cn} from './util.js'
+import {fmt_num, en_nums, cn} from './util.js'
 import {clamp} from 'es-toolkit'
 
 let {
@@ -45,7 +45,7 @@ let {
 } = $props()
 
 $effect(() => {
-    display_value = ar_nums(value)
+    display_value = fmt_num(value)
 })
 
 function handle_keydown(e) {
@@ -89,7 +89,7 @@ function handle_wheel(e) {
 
 function handle_change(e) {
     const raw_input = e.currentTarget.value.trim()
-    display_value = ar_nums(raw_input)
+    display_value = fmt_num(raw_input)
 
     if (!raw_input) {
         onpreinput(default_value)


### PR DESCRIPTION
NumberInput always showed Arabic-Indic digits regardless of locale. Switched `display_value` to the locale-aware `fmt_num` so digits follow `<html lang>` — Arabic when `lang=ar`, ASCII otherwise. Arabic-first apps are unaffected; typing still works either way.