### PR TITLE
util: apply add_zwj on all browsers, not just Safari

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -263,12 +263,10 @@ export const unescape_str = s =>
 
 /** @param {string} str */
 export function add_zwj(str) {
-    return window._useragent?.safari
-        ? str.replace(
-              /([ئبت-خس-غف-نهيی])([^ء-يی\n ]*<[^>]+>[ً-ْٰۖۗۚۛۜ]*)(?=[آ-يی])/g,
-              '$1&zwj;$2&zwj;',
-          )
-        : str
+    return str.replace(
+        /([ئبت-خس-غف-نهيی])([^ء-يی\n ]*<[^>]+>[ً-ْٰۖۗۚۛۜ]*)(?=[آ-يی])/g,
+        '$1&zwj;$2&zwj;',
+    )
 }
 
 export const multi_match_map = {


### PR DESCRIPTION
## Problem
Searching Arabic in the book/author name filters highlights the matched substring by wrapping it in `<mark>`. That splits the word into two runs, and on non-Safari browsers the letters stop joining across the boundary — e.g. searching `الب` in `البصري` renders the highlighted `الب` detached from `صري` instead of one connected word.

## Cause
`add_zwj` inserts zero-width joiners around the `<mark>` boundary so the letters keep connecting, but it was gated to `window._useragent?.safari`. On Chromium, Firefox, Android WebView, and Electron it returned the string unchanged, so the join was never repaired there.

## Fix
Run `add_zwj` on every browser. A joiner is only inserted between a dual-joining letter and a following joinable letter (the character class + lookahead already guarantee this), so it is a no-op where the letters already join — harmless on Chromium — and it restores the join on the browsers that need it. This also covers the direct `add_zwj(pg_text)` path used for reader page text, which had the same Safari-only limitation.

## Testing
- `highlight_gapped('الب', 'البصري')` → `<mark>الب&zwj;</mark>&zwj;صري` (joined)
- `highlight_gapped('البصري', 'البصري')` → `<mark>البصري</mark>` (whole word, no stray joiner)
- Plain text with no tags is returned unchanged
- Verified visually in the app on a non-Safari browser
